### PR TITLE
add user entity related files and basic security

### DIFF
--- a/blackmagic/build.gradle
+++ b/blackmagic/build.gradle
@@ -20,6 +20,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/blackmagic/src/main/java/com/sms/blackmagic/config/.gitkeep
+++ b/blackmagic/src/main/java/com/sms/blackmagic/config/.gitkeep
@@ -1,3 +1,0 @@
-temp file for git to track package for the first time
-
-you can delete if you want

--- a/blackmagic/src/main/java/com/sms/blackmagic/config/SecurityConfigurer.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/config/SecurityConfigurer.java
@@ -1,0 +1,50 @@
+package com.sms.blackmagic.config;
+
+import com.sms.blackmagic.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfigurer {
+
+    @Autowired
+    private CustomUserDetailsService userDetailsService;
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService)
+                .passwordEncoder(new BCryptPasswordEncoder());
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.authorizeHttpRequests(authorizeRequests ->
+                {
+                    try {
+                        authorizeRequests
+                                .requestMatchers(HttpMethod.POST, "/user").hasRole("ADMIN")
+                                .requestMatchers(HttpMethod.PUT, "/user").hasRole("ADMIN")
+                                .requestMatchers(HttpMethod.DELETE, "/user/**").hasRole("ADMIN")
+                                .requestMatchers(HttpMethod.GET, "/user/**").hasRole("ADMIN");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+        );
+        http.csrf().disable();
+        http.httpBasic();
+        return http.build();
+    }
+
+
+}
+

--- a/blackmagic/src/main/java/com/sms/blackmagic/controller/.gitkeep
+++ b/blackmagic/src/main/java/com/sms/blackmagic/controller/.gitkeep
@@ -1,3 +1,0 @@
-temp file for git to track package for the first time
-
-you can delete if you want

--- a/blackmagic/src/main/java/com/sms/blackmagic/controller/UserController.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/controller/UserController.java
@@ -1,0 +1,42 @@
+package com.sms.blackmagic.controller;
+
+
+import com.sms.blackmagic.dto.UserDTO;
+import com.sms.blackmagic.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public UserDTO createUser(@RequestBody UserDTO userDTO) {
+        return userService.createUser(userDTO);
+    }
+
+    @PutMapping
+    public UserDTO updateUser(@RequestBody UserDTO userDTO) {
+        return userService.updateUser(userDTO);
+    }
+
+    @DeleteMapping("/{user_id}")
+    public void deleteUser(@PathVariable("user_id") Integer userId) {
+        userService.deleteUser(userId);
+    }
+
+    @GetMapping("/{user_id}")
+    public UserDTO getUserById(@PathVariable("user_id") Integer userId) {
+        System.out.println();
+        System.out.println();
+        return userService.findUserById(userId);
+    }
+
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/dto/UserDTO.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/dto/UserDTO.java
@@ -1,0 +1,24 @@
+package com.sms.blackmagic.dto;
+
+import com.sms.blackmagic.model.Company;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+    private Integer userId;
+    private String accountName;
+    private String password;
+    private int authority;
+    private String ipAddress;
+    private String name;
+    private String email;
+    private String contact;
+    private String note;
+    private Integer companyId;
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/model/.gitkeep
+++ b/blackmagic/src/main/java/com/sms/blackmagic/model/.gitkeep
@@ -1,3 +1,0 @@
-temp file for git to track package for the first time
-
-you can delete if you want

--- a/blackmagic/src/main/java/com/sms/blackmagic/model/Company.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/model/Company.java
@@ -1,0 +1,30 @@
+package com.sms.blackmagic.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Entity
+@Table(name="company")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Integer companyId;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<User> users = new ArrayList<>();
+
+}
+

--- a/blackmagic/src/main/java/com/sms/blackmagic/model/User.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/model/User.java
@@ -1,0 +1,53 @@
+package com.sms.blackmagic.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name="user")
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer userId;
+
+    @Column(name="authority")
+    private int authority;
+
+    @Column(name="account_name")
+    private String accountName;
+
+    @Column(name="password")
+    private String password;
+
+    @Column(name="register_date")
+    @CreationTimestamp
+    private LocalDateTime registerDate;
+
+    @Column(name="ip_address")
+    private String ipAddress;
+
+    @Column(name="name")
+    private String name;
+
+    @Column(name="email")
+    private String email;
+
+    @Column(name="contact")
+    private String contact;
+
+    @Column(name="note")
+    private String note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", referencedColumnName = "company_id")
+    private Company company;
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/repository/.gitkeep
+++ b/blackmagic/src/main/java/com/sms/blackmagic/repository/.gitkeep
@@ -1,3 +1,0 @@
-temp file for git to track package for the first time
-
-you can delete if you want

--- a/blackmagic/src/main/java/com/sms/blackmagic/repository/UserRepository.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sms.blackmagic.repository;
+
+import com.sms.blackmagic.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+
+    User findByAccountName(String username);
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/service/.gitkeep
+++ b/blackmagic/src/main/java/com/sms/blackmagic/service/.gitkeep
@@ -1,3 +1,0 @@
-temp file for git to track package for the first time
-
-you can delete if you want

--- a/blackmagic/src/main/java/com/sms/blackmagic/service/CustomUserDetailsService.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/service/CustomUserDetailsService.java
@@ -1,0 +1,51 @@
+package com.sms.blackmagic.service;
+
+import com.sms.blackmagic.model.User;
+import com.sms.blackmagic.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByAccountName(username);
+
+        if (user == null) {
+            throw new UsernameNotFoundException("User not found with username: " + username);
+        }
+
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        if (user.getAuthority() == 1) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_MASTER"));
+        }
+        if (user.getAuthority() == 2) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        }
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getAccountName(),
+                user.getPassword(),
+                true,
+                true,
+                true,
+                true,
+                authorities
+        );
+    }
+
+
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/service/UserService.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/service/UserService.java
@@ -1,0 +1,10 @@
+package com.sms.blackmagic.service;
+
+import com.sms.blackmagic.dto.UserDTO;
+
+public interface UserService {
+    UserDTO createUser(UserDTO userDTO);
+    UserDTO updateUser(UserDTO userDTO);
+    void deleteUser(Integer userId);
+    UserDTO findUserById(Integer userId);
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/service/UserServiceImpl.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/service/UserServiceImpl.java
@@ -1,0 +1,46 @@
+package com.sms.blackmagic.service;
+
+import com.sms.blackmagic.dto.UserDTO;
+import com.sms.blackmagic.model.User;
+import com.sms.blackmagic.repository.UserRepository;
+import com.sms.blackmagic.util.UserConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+    private final UserConverter userConverter;
+
+    @Autowired
+    public UserServiceImpl(UserRepository userRepository, UserConverter userConverter) {
+        this.userRepository = userRepository;
+        this.userConverter = userConverter;
+    }
+
+    @Override
+    public UserDTO createUser(UserDTO userDTO) {
+        User user = userConverter.fromUserDTO(userDTO);
+        User savedUser = userRepository.save(user);
+        return userConverter.fromUser(savedUser);
+    }
+
+    @Override
+    public UserDTO updateUser(UserDTO userDTO) {
+        User user = userConverter.fromUserDTO(userDTO);
+        User updatedUser = userRepository.save(user);
+        return userConverter.fromUser(updatedUser);
+    }
+
+    @Override
+    public void deleteUser(Integer userId) {
+        userRepository.deleteById(userId);
+    }
+
+    @Override
+    public UserDTO findUserById(Integer userId) {
+        User user = userRepository.findById(userId).orElse(null);
+        return user != null ? userConverter.fromUser(user) : null;
+    }
+}

--- a/blackmagic/src/main/java/com/sms/blackmagic/util/UserConverter.java
+++ b/blackmagic/src/main/java/com/sms/blackmagic/util/UserConverter.java
@@ -1,0 +1,50 @@
+package com.sms.blackmagic.util;
+
+import com.sms.blackmagic.dto.UserDTO;
+import com.sms.blackmagic.model.Company;
+import com.sms.blackmagic.model.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+
+    private static final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public static User fromUserDTO(UserDTO userDTO) {
+        User user = new User();
+        Company company = new Company();
+        user.setUserId(userDTO.getUserId());
+        user.setAccountName(userDTO.getAccountName());
+        if (userDTO.getPassword() != null) {
+            String encodedPassword = passwordEncoder.encode(userDTO.getPassword());
+            user.setPassword(encodedPassword);
+        } else {
+            user.setPassword(userDTO.getPassword());
+        }
+        user.setAuthority(userDTO.getAuthority());
+        user.setIpAddress(userDTO.getIpAddress());
+        user.setName(userDTO.getName());
+        user.setEmail(userDTO.getEmail());
+        user.setContact(userDTO.getContact());
+        user.setNote(userDTO.getNote());
+        company.setCompanyId(userDTO.getCompanyId());
+        user.setCompany(company);
+        return user;
+    }
+
+    public static UserDTO fromUser(User user) {
+        return new UserDTO(
+                user.getUserId(),
+                user.getAccountName(),
+                "",
+                user.getAuthority(),
+                user.getIpAddress(),
+                user.getName(),
+                user.getEmail(),
+                user.getContact(),
+                user.getNote(),
+                user.getCompany().getCompanyId()
+        );
+    }
+}

--- a/blackmagic/src/main/resources/application.properties
+++ b/blackmagic/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.datasource.hikari.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.hikari.jdbc-url=jdbc:mariadb://211.234.56.43:3307/test?characterEncoding=UTF-8&serverTimezone=UTC
-spring.datasource.hikari.username=user_test
-spring.datasource.hikari.password=user
+spring.datasource.hikari.username=root
+spring.datasource.hikari.password=root
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
There are three access levels in user's authority attribute.

0 => USER(DEFAULT)
1 => MASTER
2=> ADMIN

Only ADMIN can have access to /user/** reqeusts(GET,POST,PUT,DELETE).

When there are no initial ADMIN user in your DB, you have to change SecurityConfigurer.java as below in order to permit all access for a while.

.requestMatchers(HttpMethod.POST, "/user").permitAll()
                                .requestMatchers(HttpMethod.PUT, "/user").permitAll()
                                .requestMatchers(HttpMethod.DELETE, "/user/**").permitAll()
                                .requestMatchers(HttpMethod.GET, "/user/**").permitAll()
